### PR TITLE
Implicit name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ defmodule MyApp.Payment do
 end
 ```
 
+The `:name` attribute of any given tag is implicit. For example, the following notation:
+
+```elixir
+state :pending, final: true do
+  ...
+end
+```
+
+is equivalent to:
+
+```elixir
+state name: :pending, final: true do
+  ...
+end
+```
+
 ### Extending a DSL
 
 DSLs made with Diesel are not closed. Once defined, they can still be extended by application

--- a/lib/diesel/dsl.ex
+++ b/lib/diesel/dsl.ex
@@ -100,36 +100,37 @@ defmodule Diesel.Dsl do
       defmacro unquote(root)(do: {:__block__, [], children}) do
         quote do
           @definition {unquote(@root), [], unquote(children)}
-
-          # @impl Diesel
-          # def definition, do: @definition
         end
       end
 
       defmacro unquote(root)(attrs, do: {:__block__, [], children}) do
         quote do
           @definition {unquote(@root), unquote(attrs), unquote(children)}
+        end
+      end
 
-          # @impl Diesel
-          # def definition, do: @definition
+      defmacro unquote(root)(name, attrs, do: {:__block__, [], children}) do
+        quote do
+          @definition {unquote(@root), unquote(Keyword.put(attrs, :name, name)),
+                       unquote(children)}
         end
       end
 
       defmacro unquote(root)(do: child) do
         quote do
           @definition {unquote(@root), [], [unquote(child)]}
-
-          # @impl Diesel
-          # def definition, do: @definition
         end
       end
 
       defmacro unquote(root)(attrs, do: child) do
         quote do
           @definition {unquote(@root), unquote(attrs), [unquote(child)]}
+        end
+      end
 
-          # @impl Diesel
-          # def definition, do: @definition
+      defmacro unquote(root)(name, attrs, do: child) do
+        quote do
+          @definition {unquote(@root), unquote(Keyword.put(attrs, :name, name)), [unquote(child)]}
         end
       end
 
@@ -140,8 +141,16 @@ defmodule Diesel.Dsl do
               {:{}, [line: 1], [unquote(tag), attrs, children]}
             end
 
+            defmacro unquote(tag)(name, attrs, do: {:__block__, _, children}) do
+              {:{}, [line: 1], [unquote(tag), Keyword.put(attrs, :name, name), children]}
+            end
+
             defmacro unquote(tag)(attrs, do: child) do
               {:{}, [line: 1], [unquote(tag), attrs, [child]]}
+            end
+
+            defmacro unquote(tag)(name, attrs, do: child) do
+              {:{}, [line: 1], [unquote(tag), Keyword.put(attrs, :name, name), [child]]}
             end
 
             defmacro unquote(tag)(do: {:__block__, _, children}) do
@@ -154,6 +163,10 @@ defmodule Diesel.Dsl do
 
             defmacro unquote(tag)(attrs) when is_list(attrs) do
               {:{}, [line: 1], [unquote(tag), attrs, []]}
+            end
+
+            defmacro unquote(tag)(name, attrs) when is_list(attrs) do
+              {:{}, [line: 1], [unquote(tag), Keyword.put(attrs, :name, name), []]}
             end
 
             defmacro unquote(tag)(child) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -37,5 +37,13 @@ defmodule DieselTest do
       assert Paper.pdf() =~ "%PDF"
       assert Paper.html() =~ "<html>"
     end
+
+    test "have an implicit name attribute" do
+      assert {:latex, [],
+              [
+                {:document, [name: :essai, status: :draft], []},
+                {:document, [name: :thesis], []}
+              ]} == Papers.definition()
+    end
   end
 end

--- a/test/support/papers.ex
+++ b/test/support/papers.ex
@@ -3,10 +3,10 @@ defmodule Papers do
   use Latex
 
   latex do
-    document do
+    document :essai, status: :draft do
     end
 
-    document do
+    document name: :thesis do
     end
   end
 end


### PR DESCRIPTION
# Description

Adds a convenience notation for the `name` attribute, making it implicit on any tag:

```
attribute :author, required: true do
  ...
end 
```

is the same as:

```
attribute name: :author, required: true do
  ...
end 
```
