### PR TITLE
Unnamed children in structured tags

### DIFF
--- a/guides/tutorial.md
+++ b/guides/tutorial.md
@@ -12,24 +12,24 @@ defmodule MyApp.Payments.Payment do
   fsm do
     state :pending do
       on event: :created do
-        action module: SendToGateway
+        action SendToGateway
         next state: :sent
       end
     end
 
     state :sent, timeout: 60 do
       on event: :success do
-        action module: NotifyParties
+        action NotifyParties
         next state: :accepted
       end
 
       on event: :error do
-        action module: NotifyParties
+        action NotifyParties
         next state: :declined
       end
 
       on event: :timeout do
-        action module: NotifyParties
+        action NotifyParties
         next state: :declined
       end
     end
@@ -138,15 +138,29 @@ end
 
 #### The action tag
 
-The `action` tag only supports the `name` attribute.
+The `action` supports the name of an Elixir module as its ony child:
 
 ```elixir
 defmodule MyApp.Fsm.Dsl.Action do
   use Diesel.Tag
 
   tag do
-    attribute :module, kind: :module
+    child kind: :module, min: 0
   end
+end
+```
+
+In other words, when there is a single child involved, the notation
+
+```elixir
+action SomeModule
+```
+
+is equivalent to:
+
+```elixir
+action do
+  SomeModule
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.5.1"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -14,18 +14,18 @@ defmodule DieselTest do
                  {:state, [name: :pending],
                   [
                     {:on, [event: :created],
-                     [{:action, [module: SendToGateway], []}, {:next, [state: :sent], []}]}
+                     [{:action, [], [SendToGateway]}, {:next, [state: :sent], []}]}
                   ]},
                  {
                    :state,
                    [name: :sent, timeout: 60],
                    [
                      {:on, [event: :success],
-                      [{:action, [module: NotifyParties], []}, {:next, [state: :accepted], []}]},
+                      [{:action, [], [NotifyParties]}, {:next, [state: :accepted], []}]},
                      {:on, [event: :error],
-                      [{:action, [module: NotifyParties], []}, {:next, [state: :declined], []}]},
+                      [{:action, [], [NotifyParties]}, {:next, [state: :declined], []}]},
                      {:on, [event: :timeout],
-                      [{:action, [module: NotifyParties], []}, {:next, [state: :declined], []}]}
+                      [{:action, [], [NotifyParties]}, {:next, [state: :declined], []}]}
                    ]
                  },
                  {:state, [name: :accepted], []},

--- a/test/support/fsm.ex
+++ b/test/support/fsm.ex
@@ -23,7 +23,7 @@ defmodule Fsm.Dsl.Action do
   use Diesel.Tag
 
   tag do
-    attribute :module, kind: :module
+    child kind: :module, min: 0
   end
 end
 

--- a/test/support/payment.ex
+++ b/test/support/payment.ex
@@ -1,7 +1,9 @@
 defmodule SendToGateway do
+  @moduledoc false
 end
 
 defmodule NotifyParties do
+  @moduledoc false
 end
 
 defmodule Payment do

--- a/test/support/payment.ex
+++ b/test/support/payment.ex
@@ -1,3 +1,9 @@
+defmodule SendToGateway do
+end
+
+defmodule NotifyParties do
+end
+
 defmodule Payment do
   @moduledoc false
   use Fsm
@@ -5,24 +11,24 @@ defmodule Payment do
   fsm do
     state :pending do
       on event: :created do
-        action(module: SendToGateway)
+        action(SendToGateway)
         next(state: :sent)
       end
     end
 
     state :sent, timeout: 60 do
       on event: :success do
-        action(module: NotifyParties)
+        action(NotifyParties)
         next(state: :accepted)
       end
 
       on event: :error do
-        action(module: NotifyParties)
+        action(NotifyParties)
         next(state: :declined)
       end
 
       on event: :timeout do
-        action(module: NotifyParties)
+        action(NotifyParties)
         next(state: :declined)
       end
     end


### PR DESCRIPTION
# Description

This PR improves the DSL of structured tags, so that we are now able to express children nodes without a specific name, eg primitive values such as a plain atom, Elixir module or a string or a number.