### PR TITLE
Minor dsl tweak in tests and docs

### DIFF
--- a/guides/tutorial.md
+++ b/guides/tutorial.md
@@ -145,7 +145,7 @@ defmodule MyApp.Fsm.Dsl.Action do
   use Diesel.Tag
 
   tag do
-    child kind: :module, min: 0
+    child kind: :module, min: 1, max: 1
   end
 end
 ```

--- a/test/support/fsm.ex
+++ b/test/support/fsm.ex
@@ -23,7 +23,7 @@ defmodule Fsm.Dsl.Action do
   use Diesel.Tag
 
   tag do
-    child kind: :module, min: 0
+    child kind: :module, min: 1, max: 1
   end
 end
 


### PR DESCRIPTION
# Description

In the provided tests/docs, the `action` tag is meant to accept exactly one Elixir module as its only child. 