### PR TITLE
Export formatter locals without parens

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,8 +1,8 @@
-locals_without_parents = [tag: :*, child: :*, attribute: :*]
+locals_without_parens = [tag: :*, child: :*, attribute: :*]
 
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  locals_without_parens: locals_without_parents,
+  locals_without_parens: locals_without_parens,
   export: [
     locals_without_parens: locals_without_parens
   ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,9 @@
+locals_without_parents = [tag: :*, child: :*, attribute: :*]
+
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  locals_without_parens: [tag: :*, child: :*, attribute: :*]
+  locals_without_parens: locals_without_parents,
+  export: [
+    locals_without_parens: locals_without_parens
+  ]
 ]

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -1,0 +1,23 @@
+# Installation
+
+The package can be installed by adding `diesel` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:diesel, "~> 0.5"}
+  ]
+end
+```
+
+# Formatter setup
+
+In order to avoid superfluous parenthesis when defining structured tags in your DSL, also add `diesel` to your dependencies in your `.formatter.exs`:
+
+```elixir
+[
+  inputs: [ ... ],
+  import_deps: [..., :diesel],
+  locals_without_parens: ...,
+]
+```

--- a/guides/overview.md
+++ b/guides/overview.md
@@ -7,15 +7,3 @@ DSLs built with Diesel are:
 * **declarative**: they look just like HTML
 * **structured**: the schema is checked at compile time
 * **extensible**: via package modules and generators
-
-## Installation
-
-The package can be installed by adding `diesel` to your list of dependencies in `mix.exs`:
-
-```elixir
-def deps do
-  [
-    {:diesel, "~> 0.5"}
-  ]
-end
-```

--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule Diesel.MixProject do
   defp extras do
     [
       "guides/overview.md",
+      "guides/installation.md",
       "guides/tutorial.md",
       "guides/parsers-and-generators.md",
       "guides/unstructured-tags.md",

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.5.1"
+  @version "0.5.2"
 
   def project do
     [


### PR DESCRIPTION
# Description

Follow up on 0.5.1 in order to also export the locals without parens so that we don't get annoying parenthesis when defining structured tags in projects using Diesel.