### PR TITLE
Improved Elixir module detection

### DIFF
--- a/lib/diesel/tag/validator.ex
+++ b/lib/diesel/tag/validator.ex
@@ -158,7 +158,7 @@ defmodule Diesel.Tag.Validator do
   defp tag_kind(tag) when is_binary(tag), do: :string
 
   defp tag_kind(tag) when is_atom(tag) do
-    if function_exported?(tag, :__info__, 1), do: :module, else: :atom
+    if tag |> to_string() |> String.starts_with?("Elixir."), do: :module, else: :atom
   end
 
   defp tag_kind(other) do


### PR DESCRIPTION
# Description

Similar to #11 , this fix improves the way we distringuish between an Elixir module vs an atom. The new way is not 100% elegant, but works better than the old way, especially when the module hasn't been compiled yet.