### PR TITLE
Fix DSL locals_without_parens/0 function name

### DIFF
--- a/lib/diesel/dsl.ex
+++ b/lib/diesel/dsl.ex
@@ -63,7 +63,13 @@ defmodule Diesel.Dsl do
 
       def root, do: @root
       def tags, do: @tag_names
-      def local_without_parens, do: @locals_without_parens
+
+      @doc """
+      Returns the list of locals without parens function signatures, so that they can be easily
+      included in .formatter.exs files
+      """
+      @spec locals_without_parens() :: keyword()
+      def locals_without_parens, do: @locals_without_parens
 
       def validate({tag, _, children} = node) do
         with :ok <- validate(children), do: validate_node(node)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.5.2"
+  @version "0.5.3"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -6,6 +6,10 @@ defmodule DieselTest do
       assert [:fsm, :action, :next, :on, :state] == Fsm.Dsl.tags()
     end
 
+    test "export their formatter configuration" do
+      assert [fsm: :*, action: :*, next: :*, on: :*, state: :*] == Fsm.Dsl.locals_without_parens()
+    end
+
     test "produce an internal definition" do
       assert {
                :fsm,


### PR DESCRIPTION
# Description

Small typo fix in the `locals_without_parens/0` offered by DSL modules