### PR TITLE
Parsing utility functions

### DIFF
--- a/guides/parsers-and-generators.md
+++ b/guides/parsers-and-generators.md
@@ -62,11 +62,12 @@ defmodule MyApp.Fsm do
 end
 ```
 
-The `Diesel` module provides with three convenience functions to traverse definitions:
+The `Diesel` module provides with several convenience functions to traverse definitions:
 
 * `children/2`: returns all children elements with the given tag name
 * `nodes/2`: returns all elements in the given list with the given tag name
 * `child/2`: returns the first child with the given tag name
+* `child/1`: returns the first child of the given element or list of elements
 
 ## Generating code
 

--- a/guides/parsers-and-generators.md
+++ b/guides/parsers-and-generators.md
@@ -62,6 +62,12 @@ defmodule MyApp.Fsm do
 end
 ```
 
+The `Diesel` module provides with three convenience functions to traverse definitions:
+
+* `children/2`: returns all children elements with the given tag name
+* `nodes/2`: returns all elements in the given list with the given tag name
+* `child/2`: returns the first child with the given tag name
+
 ## Generating code
 
 By implementing the `Diesel.Generator` behaviour, developers can produce elixir code, based on a DSL

--- a/lib/diesel.ex
+++ b/lib/diesel.ex
@@ -20,6 +20,7 @@ defmodule Diesel do
   end
   ```
 
+
   For more information on how to use this library, please check:
 
   * the `Diesel.Dsl` and `Diesel.Tag` modules,
@@ -27,8 +28,11 @@ defmodule Diesel do
   * the examples used in tests
   """
 
+  @type tag() :: atom()
+  @type element() :: {tag(), keyword(), [element()]}
+
   @doc "Returns the raw definition for the dsl, before compilation"
-  @callback definition() :: term()
+  @callback definition() :: element()
 
   @doc """
   Compiles the raw definition and returns a compiled version of it
@@ -130,5 +134,22 @@ defmodule Diesel do
         end
       end
     end
+  end
+
+  @doc "Returns all children elements matching the given tag"
+  @spec children(element(), tag()) :: [element()]
+  def children({_, _, children}, name) when is_list(children), do: elements(children, name)
+
+  @doc "Returns all elements matching the given name"
+  @spec elements([element()], tag()) :: [element()]
+  def elements(elements, name) when is_list(elements),
+    do: for({^name, _, _} = element <- elements, do: element)
+
+  @doc "Returns the first child element matching the given name, from the given definition"
+  @spec child(element(), tag()) :: element() | nil
+  def child({_, _, _} = element, name) do
+    element
+    |> children(name)
+    |> List.first()
   end
 end

--- a/lib/diesel.ex
+++ b/lib/diesel.ex
@@ -152,4 +152,10 @@ defmodule Diesel do
     |> children(name)
     |> List.first()
   end
+
+  @doc "Returns the first child of the given element, or list of elements"
+  @spec child(element() | [element()]) :: any()
+  def child({_, _, [child | _]}), do: child
+  def child(nodes) when is_list(nodes), do: Enum.map(nodes, &child/1)
+  def child(nil), do: nil
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.5.3"
+  @version "0.5.4"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -42,7 +42,8 @@ defmodule DieselTest do
       definition = Payment.definition()
 
       assert 4 == definition |> Diesel.children(:state) |> length
-      assert {:state, [name: :pending], _} = Diesel.child(definition, :state)
+      assert {:state, [name: :pending], _} = pending = Diesel.child(definition, :state)
+      assert {:on, [event: :created], _} = Diesel.child(pending)
       assert [] = Diesel.children(definition, :on)
     end
 

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -38,6 +38,14 @@ defmodule DieselTest do
              } == Payment.definition()
     end
 
+    test "can be parsed with utility functions" do
+      definition = Payment.definition()
+
+      assert 4 == definition |> Diesel.children(:state) |> length
+      assert {:state, [name: :pending], _} = Diesel.child(definition, :state)
+      assert [] = Diesel.children(definition, :on)
+    end
+
     test "are used to generate code" do
       assert Payment.diagram() =~ "digraph {"
     end


### PR DESCRIPTION
# Description

Adds three new utility functions:

* `Diesel.children/2`
* `Diesel.child/2`
* `Diesel.elements/2`
* `Diesel.child/1`

to make it easier to traverse and parse dsl definitions. 