### PR TITLE
Inlined lists as node children

### DIFF
--- a/lib/diesel/dsl.ex
+++ b/lib/diesel/dsl.ex
@@ -84,10 +84,12 @@ defmodule Diesel.Dsl do
         end)
       end
 
+      def validate(_), do: :ok
+
       defp validate_node({tag, _, _} = node) do
         case Map.get(@tags_by_name, tag) do
           nil ->
-            {:error, "Unsupported tag #{inspect(tag)}"}
+            {:error, "Unsupported tag '#{inspect(tag)}'"}
 
           tag ->
             with {:error, reason} <- Tag.validate(tag, node) do
@@ -95,8 +97,6 @@ defmodule Diesel.Dsl do
             end
         end
       end
-
-      def validate(_), do: :ok
 
       defmacro unquote(root_name)(do: {:__block__, [], children}) do
         quote do
@@ -177,7 +177,11 @@ defmodule Diesel.Dsl do
             end
 
             defmacro unquote(tag)(attrs) when is_list(attrs) do
-              {:{}, [line: 1], [unquote(tag), attrs, []]}
+              if Keyword.keyword?(attrs) do
+                {:{}, [line: 1], [unquote(tag), attrs, []]}
+              else
+                {:{}, [line: 1], [unquote(tag), [], attrs]}
+              end
             end
 
             defmacro unquote(tag)(child) do

--- a/lib/diesel/tag/validator.ex
+++ b/lib/diesel/tag/validator.ex
@@ -125,7 +125,7 @@ defmodule Diesel.Tag.Validator do
     Enum.reduce_while(children, :ok, fn child, _ ->
       case validate_child(child, specs) do
         :ok -> {:cont, :ok}
-        {:error, reason} -> {:halt, reason}
+        {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.5.5"
+  @version "0.5.6"
 
   def project do
     [


### PR DESCRIPTION
# Description

Small addition that brings syntax sugar when inlining lists as children of a node:

```elixir
...
actions [Action1, Action2]
...
```

And an extra "tiny" fix around DSL syntax validation I am sneaking in, since we're here...