### PR TITLE
Default dsl, parser and root tag

### DIFF
--- a/guides/tutorial.md
+++ b/guides/tutorial.md
@@ -51,11 +51,20 @@ First, lets define the `MyApp.Fsm` library module:
 defmodule MyApp.Fsm do
   use Diesel,
     otp_app: :my_app,
-    dsl: MyApp.Dsm.Dsl
+    dsl: MyApp.Dsm.Dsl  # optional
 end
 ```
 
 This module will import the api offered by the actual, which will be defined by a delegate module `MyApp.Fsm.Dsl`.
+
+**Note**: the `:dsl` key is optional. If omitted, it will default to the caller module, suffixed by
+`Dsl`. The above example is equivalent to:
+
+```elixir
+defmodule MyApp.Fsm do
+  use Diesel, otp_app: :my_app,
+end
+``
 
 ## Defining the DSL
 
@@ -72,12 +81,25 @@ We will need the following elements of the language:
 defmodule MyApp.Fsm.Dsl do
   use Diesel.Dsl,
     otp_app: :my_app,
-    root: MyApp.Fsm.Dsl.Fsm,
+    root: MyApp.Fsm.Dsl.Fsm, # optional
     tags: [
       MyApp.Fsm.Dsl.Action,
       MyApp.Fsm.Dsl.Next,
       MyApp.Fsm.Dsl.On,
       MyApp.Fsm.Dsl.State
+    ]
+end
+```
+
+**Note**: the `:root` key is optional. If ommitted, a naming convention will be applied, so that the
+above example is equivalent to:
+
+```elixir
+defmodule MyApp.Fsm.Dsl do
+  use Diesel.Dsl,
+    otp_app: :my_app,
+    tags: [
+      ...
     ]
 end
 ```
@@ -226,12 +248,35 @@ defmodule MyApp.Fsm do
     otp_app: ...,
     dsl: ...,
     parsers: [
-      Fsm.Parser
+      MyApp.Fsm.Parser
     ]
 end
 ```
 
 Please check the `Fsm.Parser` module included in `test/support/fsm.ex`.
+
+**Note**: the `:parsers` key is optional. If omitted, a default parser will be used, by appending
+the `Parser` suffix to the caller module. The above example is equivalent to:
+
+```elixir
+defmodule MyApp.Fsm do
+  use Diesel,
+    otp_app: ...,
+    dsl: ...,
+end
+```
+
+**Note**: in reality, parsers are optional. If you wish to skip them entirely, you can set an empty
+list:
+
+```elixir
+defmodule MyApp.Fsm do
+  use Diesel,
+    otp_app: ...,
+    dsl: ...,
+    parsers: []
+end
+```
 
 ## Generating code
 

--- a/lib/diesel/dsl.ex
+++ b/lib/diesel/dsl.ex
@@ -27,7 +27,10 @@ defmodule Diesel.Dsl do
   defmacro __using__(opts) do
     dsl = __CALLER__.module
     otp_app = Keyword.fetch!(opts, :otp_app)
-    root = opts |> Keyword.fetch!(:root) |> module_name()
+    default_root_tag = dsl |> Module.split() |> Enum.drop(-1) |> List.last()
+    default_root_tag = Module.concat(dsl, default_root_tag)
+
+    root = opts |> Keyword.get(:root, default_root_tag) |> module_name()
     default_tags = Keyword.get(opts, :tags, [])
 
     default_packages =

--- a/lib/diesel/tag.ex
+++ b/lib/diesel/tag.ex
@@ -18,7 +18,7 @@ defmodule Diesel.Tag do
 
   use Diesel,
     otp_app: :diesel,
-    dsl: Diesel.Tag.Dsl,
+    parsers: [],
     generators: [
       Diesel.Tag.Generator
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.5.8"
+  @version "0.5.9"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -2,6 +2,18 @@ defmodule DieselTest do
   use ExUnit.Case
 
   describe "dsls" do
+    test "have a default root tag" do
+      assert Fsm.Dsl.root() == :fsm
+    end
+
+    test "have a default parser" do
+      assert Fsm.parsers() == [Fsm.Parser]
+    end
+
+    test "have a default dsl" do
+      assert Fsm.dsl() == Fsm.Dsl
+    end
+
     test "are made of tags" do
       assert [:fsm, :action, :next, :on, :state] == Fsm.Dsl.tags()
     end

--- a/test/support/fsm.ex
+++ b/test/support/fsm.ex
@@ -51,7 +51,6 @@ defmodule Fsm.Dsl do
   @moduledoc false
   use Diesel.Dsl,
     otp_app: :diesel,
-    root: Fsm.Dsl.Fsm,
     tags: [
       Fsm.Dsl.Action,
       Fsm.Dsl.Next,
@@ -135,10 +134,7 @@ defmodule Fsm do
   @moduledoc false
   use Diesel,
     otp_app: :diesel,
-    dsl: Fsm.Dsl,
-    parsers: [
-      Fsm.Parser
-    ],
+    debug: true,
     generators: [
       Fsm.Diagram
     ]


### PR DESCRIPTION
# Description

Introduces some defaults for the dsl, parser and root tag. For example, if your caller caller module is `MyApp.MyLib`, then:

* the default dsl will be `MyApp.MyLib.Dsl`
* the default parser will be `MyApp.Mylib.Parser`
* the default root tag of the dsl will be `MyApp.MyLib.Dsl.MyLib`