### PR TITLE
Tag validation improvements

### DIFF
--- a/lib/diesel/tag/validator.ex
+++ b/lib/diesel/tag/validator.ex
@@ -10,7 +10,7 @@ defmodule Diesel.Tag.Validator do
   Validates the given node, against the given schema
   """
   @spec validate(node :: tuple(), schema :: tuple()) :: :ok | {:error, any()}
-  def validate({_tag, attrs, children}, schema) do
+  def validate({_tag, attrs, children} = node, schema) do
     attr_specs = specs(schema, :attribute)
     child_specs = specs(schema, :child)
 
@@ -18,6 +18,9 @@ defmodule Diesel.Tag.Validator do
          :ok <- validate_unexpected_attributes(attr_specs, attrs),
          :ok <- validate_expected_children(child_specs, children) do
       validate_unexpected_children(child_specs, children)
+    else
+      {:error, reason} ->
+        {:error, reason <> ". In: #{inspect(node)}"}
     end
   end
 
@@ -27,7 +30,7 @@ defmodule Diesel.Tag.Validator do
       default = Keyword.get(spec, :default, nil)
       kind = Keyword.get(spec, :kind, :string)
       required = Keyword.get(spec, :required, true)
-      allowed_values = Keyword.get(spec, :allowed, [])
+      allowed_values = Keyword.get(spec, :in, [])
       attr_value = attrs[attr_name] || default
 
       with :ok <- validate_value(attr_value, kind, required),

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.7.1"
 
   def project do
     [

--- a/test/support/fsm.ex
+++ b/test/support/fsm.ex
@@ -12,7 +12,7 @@ defmodule Fsm.Dsl.State do
   use Diesel.Tag
 
   tag do
-    attribute :name, kind: :atom, allowed: [:pending, :sent, :accepted, :declined]
+    attribute :name, kind: :atom, in: [:pending, :sent, :accepted, :declined]
     attribute :timeout, kind: :number, required: false
     child :on, min: 0
   end
@@ -43,7 +43,7 @@ defmodule Fsm.Dsl.Next do
   use Diesel.Tag
 
   tag do
-    attribute :state, kind: :atom, allowed: [:pending, :sent, :accepted, :declined]
+    attribute :state, kind: :atom, in: [:pending, :sent, :accepted, :declined]
   end
 end
 


### PR DESCRIPTION
# Description

A couple of minor fixes:

* More detailed error message when a tag fails to validate.
* Allowed values for an attribute are now specified with `in:` 