### PR TITLE
Root tag default attribute

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,13 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      checks: %{
+        disabled: [
+          {Credo.Check.Refactor.LongQuoteBlocks, []}
+        ]
+      }
+      # files etc.
+    }
+  ]
+}

--- a/lib/diesel/dsl.ex
+++ b/lib/diesel/dsl.ex
@@ -95,21 +95,39 @@ defmodule Diesel.Dsl do
         end
       end
 
-      defmacro unquote(root_name)(attrs, do: {:__block__, [], children}) do
+      defmacro unquote(root_name)(attrs, do: {:__block__, [], children}) when is_list(attrs) do
         quote do
           @definition {unquote(@root), unquote(attrs), unquote(children)}
         end
       end
 
-      defmacro unquote(root_name)(attrs, do: child) do
+      defmacro unquote(root_name)(name, do: {:__block__, [], children}) do
+        quote do
+          @definition {unquote(@root), [name: unquote(name)], unquote(children)}
+        end
+      end
+
+      defmacro unquote(root_name)(attrs, do: child) when is_list(attrs) do
         quote do
           @definition {unquote(@root), unquote(attrs), [unquote(child)]}
         end
       end
 
-      defmacro unquote(root_name)(attrs, child) do
+      defmacro unquote(root_name)(name, do: child) do
+        quote do
+          @definition {unquote(@root), [name: unquote(name)], [unquote(child)]}
+        end
+      end
+
+      defmacro unquote(root_name)(attrs, child) when is_list(attrs) do
         quote do
           @definition {unquote(@root), unquote(attrs), [unquote(child)]}
+        end
+      end
+
+      defmacro unquote(root_name)(name, child) do
+        quote do
+          @definition {unquote(@root), [name: unquote(name)], [unquote(child)]}
         end
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.7.1"
+  @version "0.7.2"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -25,7 +25,7 @@ defmodule DieselTest do
     test "produce an internal definition" do
       assert {
                :fsm,
-               [],
+               [name: "payment"],
                [
                  {:state, [name: :pending],
                   [

--- a/test/support/fsm.ex
+++ b/test/support/fsm.ex
@@ -70,7 +70,7 @@ defmodule Fsm.Parser do
   @behaviour Diesel.Parser
 
   @impl true
-  def parse({:fsm, [], states}, _opts) do
+  def parse({:fsm, [name: _], states}, _opts) do
     for {:state, state, events} <- states,
         {:on, event, transition} <- events do
       next_state = next_state(transition)

--- a/test/support/fsm.ex
+++ b/test/support/fsm.ex
@@ -3,6 +3,7 @@ defmodule Fsm.Dsl.Fsm do
   use Diesel.Tag
 
   tag do
+    attribute :name, kind: :string
     child :state, min: 1
   end
 end

--- a/test/support/payment.ex
+++ b/test/support/payment.ex
@@ -10,7 +10,7 @@ defmodule Payment do
   @moduledoc false
   use Fsm
 
-  fsm do
+  fsm "payment" do
     state :pending do
       on event: :created do
         action(SendToGateway)


### PR DESCRIPTION
# Description

A small improvement that adds support for the default `name` attribute at the root level. Eg:

```elixir
fsm "some_name" do
... 
end
```

is equivalent to: 

```elixir
fsm name: "some_name" do
... 
end
```

This was supported for children tags, but not at the root level. 