### PR TITLE
Generic attributes

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -5,7 +5,7 @@ The package can be installed by adding `diesel` to your list of dependencies in 
 ```elixir
 def deps do
   [
-    {:diesel, "~> 0.7"}
+    {:diesel, "~> 0.8"}
   ]
 end
 ```

--- a/guides/tutorial.md
+++ b/guides/tutorial.md
@@ -156,6 +156,18 @@ state name: :pending do
 end
 ```
 
+**Note**: since 0.8.0, Diesel supports generic attributes, where the name or the kind are not predefined. This can be set by using the `:*` notation:
+
+```elixir
+defmodule MyApp.MyDsl.MyTag do
+  use Diesel.Tag
+
+  tag do
+    attribute name: :*, kind: :*, min: 1
+  end
+end
+```
+
 
 #### The action tag
 

--- a/lib/diesel/tag/validator.ex
+++ b/lib/diesel/tag/validator.ex
@@ -25,6 +25,8 @@ defmodule Diesel.Tag.Validator do
   end
 
   defp validate_expected_attributes(specs, attrs) do
+    specs = Enum.reject(specs, fn spec -> spec[:name] == :* end)
+
     Enum.reduce_while(specs, :ok, fn spec, _ ->
       attr_name = spec[:name]
       default = Keyword.get(spec, :default, nil)
@@ -163,10 +165,13 @@ defmodule Diesel.Tag.Validator do
   end
 
   defp expected_name?(name, specs),
-    do: Enum.find(specs, fn spec -> is_nil(spec[:name]) || spec[:name] == name end)
+    do:
+      Enum.find(specs, fn spec ->
+        is_nil(spec[:name]) || spec[:name] == :* || spec[:name] == name
+      end)
 
   defp expected_child_kind?(kind, specs) do
-    Enum.find(specs, fn spec -> spec[:kind] == :any || spec[:kind] == kind end)
+    Enum.find(specs, fn spec -> spec[:kind] in [:any, :*] || spec[:kind] == kind end)
   end
 
   defp tag_kind({_, _, _}), do: :tag

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.7.2"
+  @version "0.8.0"
 
   def project do
     [

--- a/test/diesel/validator_test.exs
+++ b/test/diesel/validator_test.exs
@@ -15,5 +15,12 @@ defmodule Diesel.ValidatorTest do
       schema = {:tag, [], [{:child, [kind: :any, min: 2, max: 2], []}]}
       assert :ok == Validator.validate(node, schema)
     end
+
+    test "allows generic attributes with unspecified names and kinds" do
+      node = {:conditions, [{:a, 1}, {:b, 2}], []}
+      schema = {:tag, [], [{:attribute, [name: :*, kind: :*, min: 1], []}]}
+
+      assert :ok == Validator.validate(node, schema)
+    end
   end
 end


### PR DESCRIPTION
# Description

Adds support for generic attributes, where the name or the kind are not known upfront. Eg:

```elixir
defmodule MyApp.MyDsl.MyTag do
  use Diesel.Tag

  tag do
    attribute name: :*, kind: :*, min: 1
  end
end
```

