### PR TITLE
Default attributes

### DIFF
--- a/lib/diesel.ex
+++ b/lib/diesel.ex
@@ -86,7 +86,8 @@ defmodule Diesel do
           if definition do
             parsers = Module.get_attribute(mod, :parsers)
             generators = Module.get_attribute(mod, :generators)
-            Diesel.Dsl.validate!(dsl, definition)
+
+            definition = Diesel.Dsl.validate!(dsl, definition)
 
             definition = Enum.reduce(parsers, definition, & &1.parse(&2, opts))
 

--- a/lib/diesel.ex
+++ b/lib/diesel.ex
@@ -87,7 +87,8 @@ defmodule Diesel do
             parsers = Module.get_attribute(mod, :parsers)
             generators = Module.get_attribute(mod, :generators)
 
-            definition = Diesel.Dsl.validate!(dsl, definition)
+            validated_definition = Diesel.Dsl.validate!(dsl, definition)
+            Module.put_attribute(mod, :definition, validated_definition)
 
             definition = Enum.reduce(parsers, definition, & &1.parse(&2, opts))
 

--- a/lib/diesel/dsl.ex
+++ b/lib/diesel/dsl.ex
@@ -65,9 +65,9 @@ defmodule Diesel.Dsl do
 
       def validate(nodes) when is_list(nodes) do
         with validated_nodes when is_list(validated_nodes) <-
-               Enum.reduce_while(nodes, [], fn node, validated_node ->
+               Enum.reduce_while(nodes, [], fn node, validated_nodes ->
                  case validate(node) do
-                   {:ok, node} -> {:cont, [node | validated_node]}
+                   {:ok, node} -> {:cont, [node | validated_nodes]}
                    {:error, _} = error -> {:halt, error}
                  end
                end),
@@ -78,8 +78,8 @@ defmodule Diesel.Dsl do
 
       defp validate_node({tag, _, _} = node) do
         with tag when not is_nil(tag) <- Map.get(@tags_by_name, tag),
-             {:ok, tag} <- Tag.validate(tag, node) do
-          {:ok, tag}
+             {:ok, validated_node} <- Tag.validate(tag, node) do
+          {:ok, validated_node}
         else
           nil -> {:error, "Unsupported tag '#{inspect(tag)}'"}
           {:error, reason} -> {:error, "in tag '#{Tag.name(tag)}'. #{reason}"}

--- a/lib/diesel/tag.ex
+++ b/lib/diesel/tag.ex
@@ -30,7 +30,7 @@ defmodule Diesel.Tag do
 
   For plain atom tags, this function will always return success.
   """
-  def validate(tag, node), do: if(structured?(tag), do: tag.validate(node), else: :ok)
+  def validate(tag, node), do: if(structured?(tag), do: tag.validate(node), else: {:ok, node})
 
   @doc """
   Returns whether a tag is structured or not

--- a/lib/diesel/tag/validator.ex
+++ b/lib/diesel/tag/validator.ex
@@ -36,7 +36,7 @@ defmodule Diesel.Tag.Validator do
   defp validate_expected_named_attributes(specs, attrs) do
     specs = Enum.reject(specs, fn spec -> spec[:name] == :* end)
 
-    with validated_attrs when is_list(attrs) <-
+    with validated_attrs when is_list(validated_attrs) <-
            Enum.reduce_while(specs, [], fn spec, validated_attrs ->
              attr_name = Keyword.fetch!(spec, :name)
              attr_value = attrs[attr_name]
@@ -73,11 +73,11 @@ defmodule Diesel.Tag.Validator do
     default = Keyword.get(spec, :default, nil)
     required = Keyword.get(spec, :required, true)
     allowed_values = Keyword.get(spec, :in, [])
-    attr_value = attr_value || default
+    attr_value = attr_value
 
-    with :ok <- validate_value(attr_value, kind, required),
-         :ok <- validate_allowed(attr_value, allowed_values) do
-      {:ok, {attr_name, attr_value}}
+    with {:ok, validated_value} <- validate_value(attr_value, kind, required, default),
+         :ok <- validate_allowed(validated_value, allowed_values) do
+      {:ok, {attr_name, validated_value}}
     end
   end
 
@@ -152,7 +152,7 @@ defmodule Diesel.Tag.Validator do
     end)
   end
 
-  @valid_kinds [:tag, :atom, :module, :boolean, :number, :string, :any]
+  @valid_kinds [:tag, :atom, :module, :boolean, :number, :string, :any, :integer, :float]
 
   defp ensure_valid_kind!(kind, spec) do
     unless Enum.member?(@valid_kinds, kind) do
@@ -222,58 +222,121 @@ defmodule Diesel.Tag.Validator do
     raise "Unrecognized element in dsl: #{inspect(other)}"
   end
 
-  defp validate_value(nil, _, true), do: {:error, "value is missing"}
-  defp validate_value(nil, _, false), do: :ok
+  defp validate_value(nil, kind, true, nil),
+    do: {:error, "expected a value of type #{kind}, got nil and no default was provided"}
 
-  defp validate_value(value, :string, _) when not is_binary(value),
+  defp validate_value(nil, _kind, _required, default), do: {:ok, default}
+
+  defp validate_value(value, :any, _required, _default), do: {:ok, value}
+  defp validate_value(values, :list, _required, _default) when is_list(values), do: {:ok, values}
+
+  defp validate_value(value, :string, _required, _default) when is_binary(value), do: {:ok, value}
+
+  defp validate_value(value, :string, _required, _default),
     do: {:error, "expected a string, got #{inspect(value)}"}
 
-  defp validate_value(value, :number, _) when not is_number(value),
+  defp validate_value(value, :number, _required, _default) when is_number(value), do: {:ok, value}
+
+  defp validate_value(value, :number, _required, _default),
     do: {:error, "Expected a number, got #{inspect(value)}"}
 
-  defp validate_value(value, :boolean, _) when not is_boolean(value),
+  defp validate_value(value, :integer, _required, _default) when is_integer(value),
+    do: {:ok, value}
+
+  defp validate_value(value, :integer, _required, _default),
+    do: {:error, "Expected an integer, got #{inspect(value)}"}
+
+  defp validate_value(value, :float, _required, _default) when is_float(value),
+    do: {:ok, value}
+
+  defp validate_value(value, :float, _required, _default),
+    do: {:error, "Expected a float, got #{inspect(value)}"}
+
+  defp validate_value(value, :boolean, _required, _default) when is_boolean(value),
+    do: {:ok, value}
+
+  defp validate_value(value, :boolean, _required, _default),
     do: {:error, "Expected a boolean, got #{inspect(value)}"}
 
-  defp validate_value(value, :atom, _) when not is_atom(value),
+  defp validate_value(value, :atom, _required, _default) when is_atom(value), do: {:ok, value}
+
+  defp validate_value(value, :atom, _required, _default),
     do: {:error, "Expected an atom, got #{inspect(value)}"}
 
-  defp validate_value([], :strings, true),
-    do: {:error, "Expected a list of strings, got an empty list"}
+  defp validate_value(value, :module, _required, _default) when is_atom(value), do: {:ok, value}
 
-  defp validate_value(values, :strings, _) when is_list(values) do
-    Enum.reduce_while(values, :ok, fn value, _ ->
-      case validate_value(value, :string, true) do
-        :ok -> {:cont, :ok}
-        error -> {:halt, error}
-      end
-    end)
+  defp validate_value(value, :module, _required, _default),
+    do: {:error, "Expected an module, got #{inspect(value)}"}
+
+  defp validate_value([], :strings, true, default) when default == [] or is_nil(default),
+    do: {:error, "Expected a non-empty list of strings, got none"}
+
+  defp validate_value([], :strings, required, default)
+       when is_list(default) and length(default) > 0,
+       do: validate_value(default, :strings, required, default)
+
+  defp validate_value(values, :strings, _required, _default) when is_list(values),
+    do: validate_values(values, :string)
+
+  defp validate_value([], :numbers, true, default) when default == [] or is_nil(default),
+    do: {:error, "Expected a non-empty list of numbers, got none"}
+
+  defp validate_value([], :numbers, required, default)
+       when is_list(default) and length(default) > 0,
+       do: validate_value(default, :numbers, required, default)
+
+  defp validate_value(values, :numbers, _required, _default) when is_list(values),
+    do: validate_values(values, :number)
+
+  defp validate_value([], :integers, true, default) when default == [] or is_nil(default),
+    do: {:error, "Expected a non-empty list of integers, got none"}
+
+  defp validate_value([], :integers, required, default)
+       when is_list(default) and length(default) > 0,
+       do: validate_value(default, :integer, required, default)
+
+  defp validate_value(values, :integers, _required, _default) when is_list(values),
+    do: validate_values(values, :integer)
+
+  defp validate_value([], :floats, true, default) when default == [] or is_nil(default),
+    do: {:error, "Expected a non-empty list of floats, got none"}
+
+  defp validate_value([], :floats, required, default)
+       when is_list(default) and length(default) > 0,
+       do: validate_value(default, :float, required, default)
+
+  defp validate_value(values, :floats, _required, _default) when is_list(values),
+    do: validate_values(values, :float)
+
+  defp validate_value([], :atoms, true, default) when default == [] or is_nil(default),
+    do: {:error, "expected a non-empty list of atoms, got none"}
+
+  defp validate_value([], :atoms, required, default)
+       when is_list(default) and length(default) > 0,
+       do: validate_value(default, :atoms, required, default)
+
+  defp validate_value(values, :atoms, _required, _default) when is_list(values),
+    do: validate_values(values, :atom)
+
+  defp validate_value(value, :*, _, _default), do: {:ok, value}
+
+  defp validate_value(value, kind, _, _default) do
+    {:error, "don't know how to validate #{inspect(value)} of type #{inspect(kind)}"}
   end
 
-  defp validate_value([], :number, true),
-    do: {:error, "Expected a list of numbers, got an empty list"}
-
-  defp validate_value(values, :numbers, _) when is_list(values) do
-    Enum.reduce_while(values, :ok, fn value, _ ->
-      case validate_value(value, :number, true) do
-        :ok -> {:cont, :ok}
-        error -> {:halt, error}
+  defp validate_values(values, kind) do
+    values
+    |> Enum.reduce_while([], fn value, acc ->
+      case validate_value(value, kind, true, nil) do
+        {:ok, value} -> {:cont, [value | acc]}
+        {:error, _} = error -> {:halt, error}
       end
     end)
-  end
-
-  defp validate_value([], :atoms, true),
-    do: {:error, "expected a list of atoms, got an empty list"}
-
-  defp validate_value(values, :atoms, _) when is_list(values) do
-    Enum.reduce_while(values, :ok, fn value, _ ->
-      case validate_value(value, :atom, true) do
-        :ok -> {:cont, :ok}
-        error -> {:halt, error}
-      end
+    |> then(fn
+      values when is_list(values) -> {:ok, Enum.reverse(values)}
+      {:error, _} = error -> error
     end)
   end
-
-  defp validate_value(_value, _kind, _required), do: :ok
 
   defp validate_allowed(_value, []), do: :ok
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -27,7 +27,7 @@ defmodule DieselTest do
                :fsm,
                [name: "payment"],
                [
-                 {:state, [name: :pending],
+                 {:state, [name: :pending, timeout: 0],
                   [
                     {:on, [event: :created],
                      [{:action, [], [SendToGateway]}, {:next, [state: :sent], []}]}
@@ -44,8 +44,8 @@ defmodule DieselTest do
                       [{:action, [], [NotifyParties]}, {:next, [state: :declined], []}]}
                    ]
                  },
-                 {:state, [name: :accepted], []},
-                 {:state, [name: :declined], []}
+                 {:state, [name: :accepted, timeout: 0], []},
+                 {:state, [name: :declined, timeout: 0], []}
                ]
              } == Payment.definition()
     end

--- a/test/diesel/validator_test.exs
+++ b/test/diesel/validator_test.exs
@@ -7,20 +7,38 @@ defmodule Diesel.ValidatorTest do
     test "allows unspecified kinds of literal children" do
       node = {:equal, [], [1, "b"]}
       schema = {:tag, [], [{:child, [kind: :any, min: 2, max: 2], []}]}
-      assert :ok == Validator.validate(node, schema)
+      assert {:ok, node} == Validator.validate(node, schema)
     end
 
     test "allows unspecified kinds of node children" do
       node = {:equal, [], [{:path, [], ["current_user.name"]}, "b"]}
       schema = {:tag, [], [{:child, [kind: :any, min: 2, max: 2], []}]}
-      assert :ok == Validator.validate(node, schema)
+      assert {:ok, node} == Validator.validate(node, schema)
     end
 
     test "allows generic attributes with unspecified names and kinds" do
       node = {:conditions, [{:a, 1}, {:b, 2}], []}
       schema = {:tag, [], [{:attribute, [name: :*, kind: :*, min: 1], []}]}
 
-      assert :ok == Validator.validate(node, schema)
+      assert {:ok, node} == Validator.validate(node, schema)
+    end
+
+    test "validates attributes with a default boolean set to false" do
+      node = {:conditions, [], []}
+      schema = {:tag, [], [{:attribute, [name: :public, kind: :boolean, default: false], []}]}
+      assert {:ok, {:conditions, [{:public, false}], []}} == Validator.validate(node, schema)
+    end
+
+    test "validates attributes with a default list" do
+      node = {:conditions, [], []}
+      schema = {:tag, [], [{:attribute, [name: :roles, kind: :atoms, default: [:user]], []}]}
+      assert {:ok, {:conditions, [{:roles, [:user]}], []}} == Validator.validate(node, schema)
+    end
+
+    test "ignores default values" do
+      node = {:conditions, [active: true], []}
+      schema = {:tag, [], [{:attribute, [name: :active, kind: :boolean, default: false], []}]}
+      assert {:ok, {:conditions, [{:active, true}], []}} == Validator.validate(node, schema)
     end
   end
 end

--- a/test/diesel/validator_test.exs
+++ b/test/diesel/validator_test.exs
@@ -4,6 +4,24 @@ defmodule Diesel.ValidatorTest do
   alias Diesel.Tag.Validator
 
   describe "validate/2" do
+    test "allows attributes of type integer" do
+      node = {:conditions, [timeout: 5], []}
+      schema = {:tag, [], [{:attribute, [name: :timeout, kind: :integer], []}]}
+      assert {:ok, {:conditions, [{:timeout, 5}], []}} == Validator.validate(node, schema)
+    end
+
+    test "allows attributes of type any" do
+      node = {:conditions, [default: :foo], []}
+      schema = {:tag, [], [{:attribute, [name: :default, kind: :any], []}]}
+      assert {:ok, {:conditions, [{:default, :foo}], []}} == Validator.validate(node, schema)
+    end
+
+    test "allows attributes of type list" do
+      node = {:conditions, [in: [1, 2]], []}
+      schema = {:tag, [], [{:attribute, [name: :in, kind: :list], []}]}
+      assert {:ok, {:conditions, [{:in, [1, 2]}], []}} == Validator.validate(node, schema)
+    end
+
     test "allows unspecified kinds of literal children" do
       node = {:equal, [], [1, "b"]}
       schema = {:tag, [], [{:child, [kind: :any, min: 2, max: 2], []}]}
@@ -23,6 +41,35 @@ defmodule Diesel.ValidatorTest do
       assert {:ok, node} == Validator.validate(node, schema)
     end
 
+    test "validates optional attributes of type number with a default value" do
+      node = {:conditions, [], []}
+
+      schema =
+        {:tag, [],
+         [{:attribute, [name: :timeout, kind: :number, default: 0, required: false], []}]}
+
+      assert {:ok, {:conditions, [{:timeout, 0}], []}} == Validator.validate(node, schema)
+    end
+
+    test "validates optional attributes of type atom, with with a list of allows values and a default value" do
+      node = {:route, [], []}
+
+      schema =
+        {:tag, [],
+         [
+           {:attribute,
+            [
+              name: :method,
+              kind: :atom,
+              default: :get,
+              required: false,
+              in: [:get, :post, :put, :delete]
+            ], []}
+         ]}
+
+      assert {:ok, {:route, [{:method, :get}], []}} == Validator.validate(node, schema)
+    end
+
     test "validates attributes with a default boolean set to false" do
       node = {:conditions, [], []}
       schema = {:tag, [], [{:attribute, [name: :public, kind: :boolean, default: false], []}]}
@@ -35,7 +82,19 @@ defmodule Diesel.ValidatorTest do
       assert {:ok, {:conditions, [{:roles, [:user]}], []}} == Validator.validate(node, schema)
     end
 
-    test "ignores default values" do
+    test "validates attribute of type any with a default value" do
+      node = {:conditions, [], []}
+      schema = {:tag, [], [{:attribute, [name: :default, kind: :any, default: :foo], []}]}
+      assert {:ok, {:conditions, [{:default, :foo}], []}} == Validator.validate(node, schema)
+    end
+
+    test "validates attribute of type list with a default value" do
+      node = {:conditions, [], []}
+      schema = {:tag, [], [{:attribute, [name: :in, kind: :list, default: [1, 2]], []}]}
+      assert {:ok, {:conditions, [{:in, [1, 2]}], []}} == Validator.validate(node, schema)
+    end
+
+    test "ignores default values if a value is already given" do
       node = {:conditions, [active: true], []}
       schema = {:tag, [], [{:attribute, [name: :active, kind: :boolean, default: false], []}]}
       assert {:ok, {:conditions, [{:active, true}], []}} == Validator.validate(node, schema)

--- a/test/support/fsm.ex
+++ b/test/support/fsm.ex
@@ -14,7 +14,7 @@ defmodule Fsm.Dsl.State do
 
   tag do
     attribute :name, kind: :atom, in: [:pending, :sent, :accepted, :declined]
-    attribute :timeout, kind: :number, required: false
+    attribute :timeout, kind: :number, required: false, default: 0
     child :on, min: 0
   end
 end


### PR DESCRIPTION
# Description

Adds proper support for default values for attributes. 

The syntax was there already, however it wasn't being honoured. 

As part of this, validation of attributes is now a bit more strict.