### PR TITLE
Pass validated definition to parsers

### DIFF
--- a/lib/diesel.ex
+++ b/lib/diesel.ex
@@ -87,8 +87,8 @@ defmodule Diesel do
             parsers = Module.get_attribute(mod, :parsers)
             generators = Module.get_attribute(mod, :generators)
 
-            validated_definition = Diesel.Dsl.validate!(dsl, definition)
-            Module.put_attribute(mod, :definition, validated_definition)
+            definition = Diesel.Dsl.validate!(dsl, definition)
+            Module.put_attribute(mod, :definition, definition)
 
             definition = Enum.reduce(parsers, definition, & &1.parse(&2, opts))
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
 
   def project do
     [


### PR DESCRIPTION
# Description

Fixes a bug introduced in v0.8.1, where the validated definitions were not being passed to parsers. Because of this, default values for attributes were not being automatically taken into account. 