### PR TITLE
Root tag syntax convenience

### DIFF
--- a/lib/diesel/dsl.ex
+++ b/lib/diesel/dsl.ex
@@ -98,6 +98,18 @@ defmodule Diesel.Dsl do
         end
       end
 
+      defmacro unquote(root_name)(attrs) when is_list(attrs) do
+        quote do
+          @definition {unquote(@root), unquote(attrs), []}
+        end
+      end
+
+      defmacro unquote(root_name)(name) when is_binary(name) do
+        quote do
+          @definition {unquote(@root), [name: unquote(name)], []}
+        end
+      end
+
       defmacro unquote(root_name)(attrs, do: {:__block__, [], children}) when is_list(attrs) do
         quote do
           @definition {unquote(@root), unquote(attrs), unquote(children)}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.8.2"
+  @version "0.8.3"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -67,4 +67,9 @@ defmodule DieselTest do
       assert Enum.all?(sent_transitions, &(&1.timeout == 60))
     end
   end
+
+  test "allows nodes with attributes but without children" do
+    assert {:route, [name: "/"], []} == Index.definition()
+    assert {:route, [name: "/home"], []} == Home.definition()
+  end
 end

--- a/test/support/route.ex
+++ b/test/support/route.ex
@@ -1,0 +1,78 @@
+defmodule Route.Dsl.Route do
+  @moduledoc false
+  use Diesel.Tag
+
+  tag do
+    attribute :name, kind: :string
+    child :model, min: 0
+    child :view, min: 0
+  end
+end
+
+defmodule Route.Dsl.Model do
+  @moduledoc false
+  use Diesel.Tag
+
+  tag do
+    child kind: :module, min: 1, max: 1
+  end
+end
+
+defmodule Route.Dsl.View do
+  @moduledoc false
+  use Diesel.Tag
+
+  tag do
+    child kind: :module, min: 1, max: 1
+  end
+end
+
+defmodule Route.Dsl do
+  @moduledoc false
+  use Diesel.Dsl,
+    otp_app: :diesel,
+    tags: [
+      Route.Dsl.Route,
+      Route.Dsl.Model,
+      Route.Dsl.View
+    ]
+end
+
+defmodule Route.Parser do
+  @moduledoc false
+  @behaviour Diesel.Parser
+
+  @impl true
+  def parse({:route, attrs, children}, _opts) do
+    path = Keyword.fetch!(attrs, :name)
+    models = for {:model, _, [module]} <- children, do: module
+    views = for {:view, _, [module]} <- children, do: module
+
+    {path, List.first(models), List.first(views)}
+  end
+end
+
+defmodule Route do
+  @moduledoc false
+  use Diesel,
+    otp_app: :diesel,
+    generators: []
+
+  defstruct [:path, :model, :view]
+end
+
+defmodule Index do
+  @moduledoc false
+
+  use Route
+
+  route("/")
+end
+
+defmodule Home do
+  @moduledoc false
+
+  use Route
+
+  route(name: "/home")
+end


### PR DESCRIPTION
# Description

Adds a small syntax convenience so that:

```elixir
some_tag "foo"
```

is equivalent to:

```elixir
some_tag "foo" do
 ...
end
```