### PR TITLE
Support lists in name attributes

### DIFF
--- a/lib/diesel/dsl.ex
+++ b/lib/diesel/dsl.ex
@@ -99,8 +99,14 @@ defmodule Diesel.Dsl do
       end
 
       defmacro unquote(root_name)(attrs) when is_list(attrs) do
-        quote do
-          @definition {unquote(@root), unquote(attrs), []}
+        if Keyword.keyword?(attrs) do
+          quote do
+            @definition {unquote(@root), unquote(attrs), []}
+          end
+        else
+          quote do
+            @definition {unquote(@root), [name: unquote(attrs)], []}
+          end
         end
       end
 
@@ -111,8 +117,14 @@ defmodule Diesel.Dsl do
       end
 
       defmacro unquote(root_name)(attrs, do: {:__block__, [], children}) when is_list(attrs) do
-        quote do
-          @definition {unquote(@root), unquote(attrs), unquote(children)}
+        if Keyword.keyword?(attrs) do
+          quote do
+            @definition {unquote(@root), unquote(attrs), unquote(children)}
+          end
+        else
+          quote do
+            @definition {unquote(@root), [name: unquote(attrs)], unquote(children)}
+          end
         end
       end
 
@@ -123,8 +135,14 @@ defmodule Diesel.Dsl do
       end
 
       defmacro unquote(root_name)(attrs, do: child) when is_list(attrs) do
-        quote do
-          @definition {unquote(@root), unquote(attrs), [unquote(child)]}
+        if Keyword.keyword?(attrs) do
+          quote do
+            @definition {unquote(@root), unquote(attrs), [unquote(child)]}
+          end
+        else
+          quote do
+            @definition {unquote(@root), [name: unquote(attrs)], [unquote(child)]}
+          end
         end
       end
 
@@ -135,8 +153,14 @@ defmodule Diesel.Dsl do
       end
 
       defmacro unquote(root_name)(attrs, child) when is_list(attrs) do
-        quote do
-          @definition {unquote(@root), unquote(attrs), [unquote(child)]}
+        if Keyword.keyword?(attrs) do
+          quote do
+            @definition {unquote(@root), unquote(attrs), [unquote(child)]}
+          end
+        else
+          quote do
+            @definition {unquote(@root), [name: unquote(attrs)], [unquote(child)]}
+          end
         end
       end
 
@@ -175,7 +199,11 @@ defmodule Diesel.Dsl do
         Enum.map(tag_names, fn tag ->
           quote do
             defmacro unquote(tag)(attrs, do: {:__block__, _, children}) when is_list(attrs) do
-              {:{}, [line: 1], [unquote(tag), attrs, children]}
+              if Keyword.keyword?(attrs) do
+                {:{}, [line: 1], [unquote(tag), attrs, children]}
+              else
+                {:{}, [line: 1], [unquote(tag), [name: attrs], children]}
+              end
             end
 
             defmacro unquote(tag)(attr, do: {:__block__, _, children}) do
@@ -187,7 +215,11 @@ defmodule Diesel.Dsl do
             end
 
             defmacro unquote(tag)(attrs, do: child) when is_list(attrs) do
-              {:{}, [line: 1], [unquote(tag), attrs, [child]]}
+              if Keyword.keyword?(attrs) do
+                {:{}, [line: 1], [unquote(tag), attrs, [child]]}
+              else
+                {:{}, [line: 1], [unquote(tag), [name: attrs], [child]]}
+              end
             end
 
             defmacro unquote(tag)(attr, do: child) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.8.4"
+  @version "0.9.0"
 
   def project do
     [

--- a/test/diesel/diesel_test.exs
+++ b/test/diesel/diesel_test.exs
@@ -15,11 +15,12 @@ defmodule DieselTest do
     end
 
     test "are made of tags" do
-      assert [:fsm, :action, :next, :on, :state] == Fsm.Dsl.tags()
+      assert [:fsm, :action, :next, :on, :state, :states] == Fsm.Dsl.tags()
     end
 
     test "export their formatter configuration" do
-      assert [fsm: :*, action: :*, next: :*, on: :*, state: :*] == Fsm.Dsl.locals_without_parens()
+      assert [fsm: :*, action: :*, next: :*, on: :*, state: :*, states: :*] ==
+               Fsm.Dsl.locals_without_parens()
     end
 
     test "produce an internal definition" do
@@ -45,7 +46,8 @@ defmodule DieselTest do
                    ]
                  },
                  {:state, [name: :accepted, timeout: 1], []},
-                 {:state, [name: :declined, timeout: 1], []}
+                 {:state, [name: :declined, timeout: 1], []},
+                 {:states, [name: [:accepted, :declined]], []}
                ]
              } == Payment.definition()
     end

--- a/test/support/fsm.ex
+++ b/test/support/fsm.ex
@@ -5,6 +5,7 @@ defmodule Fsm.Dsl.Fsm do
   tag do
     attribute :name, kind: :string
     child :state, min: 1
+    child :states, min: 0
   end
 end
 
@@ -16,6 +17,15 @@ defmodule Fsm.Dsl.State do
     attribute :name, kind: :atom, in: [:pending, :sent, :accepted, :declined]
     attribute :timeout, kind: :number, required: false, default: 1
     child :on, min: 0
+  end
+end
+
+defmodule Fsm.Dsl.States do
+  @moduledoc false
+  use Diesel.Tag
+
+  tag do
+    attribute :name, kind: :atoms
   end
 end
 
@@ -56,7 +66,8 @@ defmodule Fsm.Dsl do
       Fsm.Dsl.Action,
       Fsm.Dsl.Next,
       Fsm.Dsl.On,
-      Fsm.Dsl.State
+      Fsm.Dsl.State,
+      Fsm.Dsl.States
     ]
 end
 

--- a/test/support/payment.ex
+++ b/test/support/payment.ex
@@ -40,5 +40,8 @@ defmodule Payment do
 
     state :declined do
     end
+
+    states [:accepted, :declined] do
+    end
   end
 end


### PR DESCRIPTION
# Description

Adds the ability to define `name` attributes that can have values of type list. For example:

```elixir
some_tag [:a, :b] do 
   ...
end
```

would be the same as:

```elixir
some_tag name: [:a, :b] do
...
end
```

and would get parsed as: 

```elixir
{:some_tag, [name: [:a, :b]], []}
```


