### PR TITLE
Attributes of multiple known types

### DIFF
--- a/lib/diesel/tag/validator.ex
+++ b/lib/diesel/tag/validator.ex
@@ -319,6 +319,19 @@ defmodule Diesel.Tag.Validator do
 
   defp validate_value(value, :*, _, _default), do: {:ok, value}
 
+  defp validate_value(value, kinds, required, default) when is_list(kinds) do
+    Enum.reduce_while(
+      kinds,
+      {:error, "expected the type to be one of #{inspect(kinds)}"},
+      fn kind, error ->
+        case validate_value(value, kind, required, default) do
+          {:ok, value} -> {:halt, {:ok, value}}
+          {:error, _} -> {:cont, error}
+        end
+      end
+    )
+  end
+
   defp validate_value(value, kind, _, _default) do
     {:error, "don't know how to validate #{inspect(value)} of type #{inspect(kind)}"}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Diesel.MixProject do
   use Mix.Project
 
-  @version "0.8.5"
+  @version "0.8.6"
 
   def project do
     [

--- a/test/diesel/validator_test.exs
+++ b/test/diesel/validator_test.exs
@@ -94,6 +94,22 @@ defmodule Diesel.ValidatorTest do
       assert {:ok, {:conditions, [{:in, [1, 2]}], []}} == Validator.validate(node, schema)
     end
 
+    test "validates attributes of multiple possible types" do
+      schema = {:tag, [], [{:attribute, [name: :timeout, kind: [:integer, :atom]], []}]}
+
+      node = {:state, [timeout: 5], []}
+      assert {:ok, {:state, [{:timeout, 5}], []}} == Validator.validate(node, schema)
+
+      node = {:state, [timeout: :some_timeout], []}
+      assert {:ok, {:state, [{:timeout, :some_timeout}], []}} == Validator.validate(node, schema)
+
+      node = {:state, [timeout: "invalid"], []}
+      assert {:error, reason} = Validator.validate(node, schema)
+
+      assert reason ==
+               "Error in attribute 'timeout' of value 'invalid': expected the type to be one of [:integer, :atom]. In: {:state, [timeout: \"invalid\"], []}"
+    end
+
     test "ignores default values if a value is already given" do
       node = {:conditions, [active: true], []}
       schema = {:tag, [], [{:attribute, [name: :active, kind: :boolean, default: false], []}]}


### PR DESCRIPTION
# Description

Improves the validation of attributes so that multiple types can be defined. Eg: 

```elixir
attribute :timeout, kind: [:integer, :atom] ...
```

is saying that the `timeout` attribute can be either an integer, or an atom. This saves parsers from having to do the syntax validation, and then just focus on the semantic interpretation of the value. 